### PR TITLE
Refactor help view into frame

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,14 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import useAccountData from './hooks/useAccountData.ts'
 import useAccountSaver from './hooks/useAccountSaver.ts'
 import type { AccountData } from './types/account.ts'
+import HelpView from './help/HelpView.tsx'
 
 const defaultProfile: AccountData = { name: '' }
 
 export default function App() {
-  const { data, loading, error } = useAccountData()
+  const { loading, error } = useAccountData()
   const save = useAccountSaver()
-  const [name, setName] = useState('')
-
-  useEffect(() => {
-    if (data) setName(data.name)
-  }, [data])
 
   useEffect(() => {
     if (error === 'profile.json not found') {
@@ -20,20 +16,7 @@ export default function App() {
     }
   }, [error, save])
 
-  const handleSave = () => {
-    save({ name })
-  }
-
   if (loading) return <p>Loading...</p>
 
-  return (
-    <div>
-      <input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Your name"
-      />
-      <button onClick={handleSave}>Save</button>
-    </div>
-  )
+  return <HelpView />
 }

--- a/src/help/HelpView.tsx
+++ b/src/help/HelpView.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { HelpCircle, BookOpen, MessageCircle, FileQuestion } from 'lucide-react'
 
-const HelpView: React.FC = () => {
+export default function HelpView() {
   return (
     <div className="animate-fadeIn">
       <h1 className="text-2xl font-bold mb-6 flex items-center">
@@ -94,5 +93,3 @@ const HelpView: React.FC = () => {
     </div>
   )
 }
-
-export default HelpView


### PR DESCRIPTION
## Summary
- move HelpView from `old/` into `src/help`
- render the help page inside the Artifact frame
- keep the data hooks to initialize profile.json
- remove the old directory

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_68478efeab74832bb7ac1ddcf4639ff8